### PR TITLE
Fix sklearn deprecations and cvxpy warnings

### DIFF
--- a/dwd/__init__.py
+++ b/dwd/__init__.py
@@ -1,6 +1,6 @@
 """Distance Weighted Discrimination for Python"""
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 from .dwd import DWD
 from .gen_dwd import GenDWD, GenDWDCV

--- a/dwd/cv.py
+++ b/dwd/cv.py
@@ -1,5 +1,5 @@
 from sklearn.base import clone
-from sklearn.metrics.scorer import check_scoring
+from sklearn.metrics import check_scoring
 from sklearn.utils import check_X_y
 from sklearn.model_selection import check_cv
 from time import time

--- a/dwd/dwd.py
+++ b/dwd/dwd.py
@@ -2,11 +2,11 @@ import cvxpy as cp
 import numpy as np
 
 from sklearn.base import BaseEstimator
-from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils import check_X_y
 from sklearn.metrics.pairwise import euclidean_distances
 
 from dwd.utils import pm1
+from dwd.linear_model import LinearClassifierMixin
 
 
 class DWD(BaseEstimator, LinearClassifierMixin):

--- a/dwd/dwd.py
+++ b/dwd/dwd.py
@@ -116,6 +116,7 @@ def solve_dwd_socp(X, y, C=1.0, sample_weight=None, solver_kws={}):
 
     # optimization variables
     beta = cp.Variable(shape=n_features)
+    X_beta = cp.Variable(shape=n_samples)  # to prevent `Y_tilde @ X @ beta` breaking DPP
     intercept = cp.Variable()
     eta = cp.Variable(shape=n_samples, nonneg=True)
 
@@ -134,8 +135,9 @@ def solve_dwd_socp(X, y, C=1.0, sample_weight=None, solver_kws={}):
     # setup constraints
     # TODO: do we need explicit SOCP constraints?
     Y_tilde = cp.diag(y)  # TODO: make sparse
-    constraints = [rho - sigma == Y_tilde @ X @ beta + intercept * y + eta,
-                   cp.SOC(cp.Parameter(value=1), beta)]  # ||beta||_2^2 <= 1
+    constraints = [rho - sigma == Y_tilde @ X_beta + intercept * y + eta,
+                   cp.SOC(cp.Parameter(value=1), beta),
+                   X_beta == X @ beta]  # ||beta||_2^2 <= 1
 
     # rho^2 - sigma^2 >= 1
     constraints.extend([cp.SOC(rho[i], cp.vstack([sigma[i], 1]))

--- a/dwd/gen_dwd.py
+++ b/dwd/gen_dwd.py
@@ -2,11 +2,11 @@ import numpy as np
 from copy import deepcopy
 
 from sklearn.base import BaseEstimator
-from sklearn.linear_model.base import LinearClassifierMixin
 from sklearn.utils import check_X_y
 
 from dwd.utils import pm1
 from dwd.cv import run_cv
+from dwd.linear_model import LinearClassifierMixin
 
 
 class GenDWD(BaseEstimator, LinearClassifierMixin):

--- a/dwd/linear_model.py
+++ b/dwd/linear_model.py
@@ -1,0 +1,35 @@
+from abc import ABCMeta
+import typing
+
+from sklearn.base import ClassifierMixin
+from sklearn.utils import check_array
+from sklearn.utils.validation import check_is_fitted
+from sklearn.utils.extmath import safe_sparse_dot
+
+import numpy as np
+
+__all__ = ['LinearClassifierMixin']
+
+
+class LinearClassifierMixin(ClassifierMixin):
+    """
+    Simplified version of sklearn.linear_model._base.LinearClassifierMixin.
+    It was removed from the public API, so must be implemented here. Because this is only
+    used for DWD and SVM predictors, I do not implement all the extra functionality as in
+    the private sklearn.linear_model API.
+
+    Expects instance variables `coef_`, `intercept_`, and `classes_` to be present on the object.
+    """
+
+    def decision_function(self, X):
+        check_is_fitted(self)
+
+        X = check_array(X, accept_sparse=['csr', 'csc', 'coo'])
+        return safe_sparse_dot(X, self.coef_.T, dense_output=True) + self.intercept_
+
+    def predict(self, X):
+        scores = self.decision_function(X)
+
+        indices = (scores > 0).astype(int)
+
+        return self.classes_[indices]

--- a/dwd/svm.py
+++ b/dwd/svm.py
@@ -2,7 +2,8 @@ import cvxpy as cp
 import numpy as np
 
 from sklearn.base import BaseEstimator  # , TransformerMixin, ClassifierMixin
-from sklearn.linear_model.base import LinearClassifierMixin
+
+from dwd.linear_model import LinearClassifierMixin
 
 
 def solve_svm(X, y, C, sample_weight=None, solver_kws={}):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = ['numpy', 'cvxpy', 'sklearn', 'matplotlib']
 
 setup(
       name='dwd',
-      version='1.0.0',
+      version='1.0.1',
       author='Iain Carmichael',
       author_email='idc9@cornell.edu',
       maintainer='Kitware Medical',


### PR DESCRIPTION
Some deprecation warnings and errors regarding `LinearClassifierMixin`, I reimplement the relevant parts in `dwd.linear_model`.

cvxpy also complained that solve_dwd_socp is not DPP-compliant, so I modify the constraints so that it is.

bump version to 1.0.1 for a separate release on pypi