### PR TITLE
COMP: Make `cvxpy` an optional dependency.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Updates
 
+## 1.0.5 (2022-01-10)
+
+- Since `cvxpy` is not supported on all platforms, make this an optional dependency installable via `pip install dwd[socp]`. 
+- Remove the import aliases from `dwd.__init__`; one must explictly import the solver to be used:
+  - `dwd.socp_dwd.DWD` (only in `dwd[socp]`)
+  - `dwd.gen_dwd.GenDWD`
+  - `dwd.gen_kern_dwd.KernGDWD`
+
 ## 1.0.4 (2021-11-19)
 
 - Rolled back dependency version pinning to restore compatibility with other versions of Python.

--- a/README.md
+++ b/README.md
@@ -31,42 +31,51 @@ tested in python 3.6.
 $ pip install dwd
 ```
 
-[Flit](https://github.com/takluyver/flit) is used for packaging, and all package metadata is stored in `pyproject.toml`. To install this project locally or for development, use `flit install` or build a pip-installable wheel with `flit build`.
+The conic solver `socp_dwd.DWD` depends on `cvxpy`, which is not available on all platforms. See [the `cvxpy` installation instructions][cvxpy]. If `cvxpy` dependencies are met, then use `pip install dwd[socp]`. 
+
+[Flit][flit] is used for packaging, and all package metadata is stored in `pyproject.toml`. To install this project locally or for development, use `flit install` or build a pip-installable wheel with `flit build`.
+
+[cvxpy]: https://www.cvxpy.org/install/index.html
+[flit]: https://github.com/takluyver/flit
 
 # Example
 
 ```python
-  from sklearn.datasets import make_blobs, make_circles
-  from dwd import DWD, KernGDWD
+from sklearn.datasets import make_blobs
+from dwd.socp_dwd import DWD
 
-  # sample sythetic training data
-  X, y = make_blobs(n_samples=200, n_features=2,
-                    centers=[[0, 0],
-                             [2, 2]])
+# sample sythetic training data
+X, y = make_blobs(
+    n_samples=200,
+    n_features=2,
+    centers=[[0, 0],
+             [2, 2]],
+)
 
-  # fit DWD classifier
-  dwd = DWD(C='auto').fit(X, y)
+# fit DWD classifier
+dwd = DWD(C='auto').fit(X, y)
 
-  # compute training accuracy
-  dwd.score(X, y)
-
-  0.94
+# compute training accuracy
+dwd.score(X, y)  # 0.94
 ```
 
 ![dwd_sep_hyperplane][dwd_sep_hyperplane]
 
 ```python
+from sklearn.datasets import make_circles
+from dwd.gen_kern_dwd import KernGDWD
+
 # sample some non-linear, toy data
 X, y = make_circles(n_samples=200, noise=0.2, factor=0.5, random_state=1)
 
 # fit kernel DWD wit gaussian kernel
-kdwd = KernGDWD(lambd=.1, kernel='rbf',
-                kernel_kws={'gamma': 1}).fit(X, y)
+kdwd = KernGDWD(
+    lambd=.1, kernel='rbf',
+    kernel_kws={'gamma': 1},
+).fit(X, y)
 
 # compute training accuracy
-kdwd.score(X, y)
-
-0.915
+kdwd.score(X, y)  # 0.915
 ```
 
 ![kern_dwd][kern_dwd]

--- a/docs/solvers.rst
+++ b/docs/solvers.rst
@@ -1,17 +1,17 @@
 DWD Classifiers
 ===============
 
-.. autoclass:: dwd.DWD
+.. autoclass:: dwd.socp_dwd.DWD
    :members: fit
    :inherited-members: predict, decision_function, score
 
-.. autoclass:: dwd.GenDWD
+.. autoclass:: dwd.gen_dwd.GenDWD
 
-.. autoclass:: dwd.KernGDWD
+.. autoclass:: dwd.gen_kern_dwd.KernGDWD
 
 Cross-validation
 ----------------
 
-.. autoclass:: dwd.GenDWDCV
+.. autoclass:: dwd.gen_dwd.GenDWDCV
 
-.. autoclass:: dwd.KernGDWDCV
+.. autoclass:: dwd.gen_kern_dwd.KernGDWDCV

--- a/dwd/__init__.py
+++ b/dwd/__init__.py
@@ -1,7 +1,3 @@
 """Distance Weighted Discrimination for Python"""
 
-__version__ = '1.0.4'
-
-from .dwd import DWD
-from .gen_dwd import GenDWD, GenDWDCV
-from .gen_kern_dwd import KernGDWD, KernGDWDCV
+__version__ = '1.0.5'

--- a/dwd/socp_dwd.py
+++ b/dwd/socp_dwd.py
@@ -1,4 +1,5 @@
-import cvxpy as cp
+import logging
+
 import numpy as np
 
 from sklearn.base import BaseEstimator
@@ -8,6 +9,13 @@ from sklearn.metrics.pairwise import euclidean_distances
 from dwd.utils import pm1
 from dwd.linear_model import LinearClassifierMixin
 
+try:
+    import cvxpy as cp
+except ImportError:
+    logging.warn(
+        'cvxpy is not installed, but is required for the conic solver.'
+    )
+    raise
 
 class DWD(BaseEstimator, LinearClassifierMixin):
     def __init__(self, C=1.0, solver_kws=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,7 @@ maintainers = [
 ]
 dependencies = [
     "numpy",
-    "cvxpy",
-    "scikit-learn"
+    "scikit-learn",
 ]
 requires-python=">=3.6"
 readme = 'README.md'
@@ -38,6 +37,9 @@ classifiers = [
 dynamic = ['version', 'description']
 
 [project.optional-dependencies]
+socp = [
+    "cvxpy",
+]
 test = []
 doc = [
     'sphinx',


### PR DESCRIPTION
Renamed `dwd.dwd` to `dwd.socp_dwd` to clarify the solver method used, and be more consistent with the other solvers.

Removed import aliases from `dwd/__init__.py` so that, if `cvxpy` is not installed, no `ImportError` is raised. This requires users to explicitly `import dwd.socp_dwd` to use the conic solver. I am a little concerned that this may be a breaking change for some users, but I don't know a better solution to the optional dependency which this introduces. In such cases, it should be safe to replace `import dwd` with `import dwd.socp_dwd as dwd` or similar (or pin the `dwd` version to `1.0.4`).

---

These are an extension of the solution proposed in https://github.com/slicersalt/dwd/issues/1#issuecomment-531806323; so resolves #1.
